### PR TITLE
PinnedList class not found fixed - 2.24.26.14

### DIFF
--- a/app/src/main/java/com/wmods/wppenhacer/xposed/core/devkit/Unobfuscator.java
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/core/devkit/Unobfuscator.java
@@ -875,7 +875,7 @@ public class Unobfuscator {
 
     public synchronized static Method loadPinnedHashSetMethod(ClassLoader loader) throws Exception {
         return UnobfuscatorCache.getInstance().getMethod(loader, () -> {
-            var clazz = findFirstClassUsingStrings(loader, StringMatchType.Contains, "SELECT jid, pinned_time FROM settings");
+            var clazz = findFirstClassUsingStrings(loader, StringMatchType.Contains, "getPinnedJids/QUERY_CHAT_SETTINGS");
             if (clazz == null) throw new Exception("PinnedList class not found");
             var method = Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getReturnType().equals(Set.class)).findFirst().orElse(null);
             if (method == null) throw new Exception("PinnedHashSet method not found");


### PR DESCRIPTION
The string used previously has been modified and is causing errors when searching for the required class, but this can be easily solved by using this new string to search.