### PR TITLE
Fix failed build : "secondary_color" is translated here but not found in default locale [ExtraTranslation]

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="conversation">Conversation Screen</string>
     <string name="primary_color">Primary Color</string>
     <string name="background_color">Background Color</string>
+    <string name="secondary_color">Secondary Color</string>
     <string name="novaconfig">New Settings Style</string>
     <string name="novaconfig_sum">Enable the new settings style, with profile photo on home screen toolbar</string>
     <string name="novofiltro">Search Functions</string>


### PR DESCRIPTION
Fix Failed Build  "secondary_color" is translated here but not found in default locale [ExtraTranslation]

```
fairuz@MacBook-Pro-3 WaEnhancer % ./gradlew assembleWhatsappRelease

> Task :app:stripWhatsappReleaseDebugSymbols
Unable to strip the following libraries, packaging them as they are: libdexkit.so.
warn: removing resource com.wmods.wppenhacer:string/secondary_color without required default value.


> Task :app:compileWhatsappReleaseJavaWithJavac
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :app:lintVitalWhatsappRelease FAILED
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-de/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Sekundärfarbe</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-es/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Color secundario</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-fr/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Couleure secondaire</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-it/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Colore secondario</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-iw/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">צבע משני</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-pt/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Cores secundárias</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-ru/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Дополнительный цвет</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-tr/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">İkincil Renk</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-zh/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">次要颜色</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-ar/strings.xml:39: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">اللون الثانوي</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-id/strings.xml:39: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Warna Sekunder</string>
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-in/strings.xml:39: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
    <string name="secondary_color">Warna Sekunder</string>
            ~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "ExtraTranslation":
   If a string appears in a specific language translation file, but there is
   no corresponding string in the default locale, then this string is probably
   unused. (It's technically possible that your application is only intended
   to run in a specific locale, but it's still a good idea to provide a
   fallback.)

   Note that these strings can lead to crashes if the string is looked up on
   any locale not providing a translation, so it's important to clean them
   up.

12 errors, 0 warnings


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintVitalWhatsappRelease'.
> Lint found fatal errors while assembling a release target.
  
  Fix the issues identified by lint, or create a baseline to see only new errors.
  To create a baseline, run `gradlew updateLintBaseline` after adding the following to the module's build.gradle file:

  android {
      lint {
          baseline = file("lint-baseline.xml")
      }
  }
 
  For more details, see https://developer.android.com/studio/write/lint#snapshot
  
  Lint found 12 errors, 0 warnings. First failure:
  
  /Users/fairuz/rnddev/WaEnhancer/app/src/main/res/values-de/strings.xml:38: Error: "secondary_color" is translated here but not found in default locale [ExtraTranslation]
      <string name="secondary_color">Sekundärfarbe</string>
              ~~~~~~~~~~~~~~~~~~~~~~
  
  The full lint text report is located at:
    /Users/fairuz/rnddev/WaEnhancer/app/build/intermediates/lint_vital_intermediate_text_report/whatsappRelease/lintVitalReportWhatsappRelease/lint-results-whatsappRelease.txt

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 17s
54 actionable tasks: 54 executed
fairuz@MacBook-Pro-3 WaEnhancer % ./gradlew assembleWhatsappRelease

```