### PR TITLE
Fix new style setting

### DIFF
--- a/app/src/main/java/com/wmods/wppenhacer/xposed/features/general/Others.java
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/features/general/Others.java
@@ -86,7 +86,7 @@ public class Others extends Feature {
         propsInteger.put(3877, oldStatus ? igstatus ? 2 : 0 : 2);
         propsBoolean.put(5171, filterSeen);
         propsBoolean.put(4497, menuWIcons);
-        propsBoolean.put(4023, newSettings);
+        propsBoolean.put(4023, false);
         propsBoolean.put(14862, newSettings);
         propsInteger.put(18564, newSettings ? 1 : 0);
 


### PR DESCRIPTION
WhatsApp recent updates changed the internal config/flag mapping for the new settings UI.
This caused the “new style setting” toggle to no longer behave correctly.

