### PR TITLE
Fix missing anti-revoke deleted DB migration / chat lag

### DIFF
--- a/app/src/main/java/com/wmods/wppenhacer/xposed/core/db/DelMessageDatabase.kt
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/core/db/DelMessageDatabase.kt
@@ -50,6 +50,28 @@ abstract class DelMessageDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS deleted_for_me (" +
+                            "_id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                            "key_id TEXT, " +
+                            "chat_jid TEXT, " +
+                            "sender_jid TEXT, " +
+                            "timestamp INTEGER, " +
+                            "original_timestamp INTEGER DEFAULT 0, " +
+                            "media_type INTEGER, " +
+                            "text_content TEXT, " +
+                            "media_path TEXT, " +
+                            "media_caption TEXT, " +
+                            "is_from_me INTEGER DEFAULT 0, " +
+                            "contact_name TEXT, " +
+                            "package_name TEXT, " +
+                            "UNIQUE(key_id, chat_jid))"
+                )
+            }
+        }
+
         private val MIGRATION_6_7 = object : Migration(6, 7) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 try {
@@ -146,6 +168,7 @@ abstract class DelMessageDatabase : RoomDatabase() {
                     .addMigrations(
                         MIGRATION_1_4,
                         MIGRATION_4_6,
+                        MIGRATION_5_6,
                         MIGRATION_6_7,
                         MIGRATION_7_8,
                         MIGRATION_8_9,

--- a/app/src/main/java/com/wmods/wppenhacer/xposed/features/general/AntiRevoke.kt
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/features/general/AntiRevoke.kt
@@ -177,6 +177,8 @@ class AntiRevoke(loader: ClassLoader, preferences: XSharedPreferences) :
         antirevokeType: String
     ) {
         if (dateTextView == null) return
+        val antirevokeValue = prefs.getString(antirevokeType, "0")?.toIntOrNull() ?: 0
+        if (antirevokeValue == 0) return
 
         val key = fMessage.key
         val messageRevokedList = getRevokedMessagesForJid(fMessage)
@@ -204,8 +206,6 @@ class AntiRevoke(loader: ClassLoader, preferences: XSharedPreferences) :
                     Utils.showToast(toastMessage, Toast.LENGTH_LONG)
                 }
             }
-
-            val antirevokeValue = prefs.getString(antirevokeType, "0")?.toIntOrNull() ?: 0
 
             when (antirevokeValue) {
                 1 -> {


### PR DESCRIPTION
## Summary

This PR fixes WhatsApp conversation lag caused by repeated WAE deleted-message database 5 -> 11 migration failures.

## Fixed

- Added the missing Room migration path from `delmessages.db` schema version 5 to 6, allowing existing WAE deleted-message history databases to migrate forward to the current schema.
- Skipped anti-revoke deleted-message DB lookups during conversation item binding when the anti-revoke display setting is disabled.

## Notes

Device was running an older version of WAE which used DB version 5. 

LSPosed modules logs showed `ConversationItemListener` repeatedly catching and logging:

```
A migration from 5 to 11 was required but not found.
```

Log produced on `AntiRevoke.bindRevokedMessageUI()` when WhatsApp renders conversation rows. Causing lag even with default WAE settings.

## Validation

- Verified local build
- Tested on device fixes for lag & migration exceptions.

GH Releases: https://github.com/JSJ-Experiments/WaEnhancer/releases/tag/debug-2ebe945
GH Actions run: https://github.com/JSJ-Experiments/WaEnhancer/actions/runs/25955403989