### PR TITLE
fix(MediaQuality): don't skip HEIC/HEIF transcode

### DIFF
--- a/app/src/main/java/com/wmods/wppenhacer/xposed/features/media/MediaQuality.kt
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/features/media/MediaQuality.kt
@@ -132,7 +132,12 @@ class MediaQuality(loader: ClassLoader, preferences: SharedPreferences) :
             Others.propsBoolean[6033] = true
             Others.propsBoolean[9569] = false
             Others.propsBoolean[26289] = true
-            Others.propsBoolean[26291] = true
+            // 26291 enables WhatsApp's Jarvis ML image-transcode config
+            // (UitTranscodeConfig/JarvisImageConfig) for this image mode. Its native
+            // passthrough decision mishandles HEIC/HEIF, uploading the source
+            // untranscoded so recipients get a corrupt image ("something wrong with
+            // the image file"). Left disabled; the maxKb/quality/maxEdge knobs above
+            // still deliver the quality boost.
             Others.propsBoolean[22375] = true
             listOf(1576, 2654, 6032, 15748, 3068).forEach { Others.propsInteger[it] = 3840 }
 

--- a/app/src/main/java/com/wmods/wppenhacer/xposed/features/media/MediaQuality.kt
+++ b/app/src/main/java/com/wmods/wppenhacer/xposed/features/media/MediaQuality.kt
@@ -132,12 +132,6 @@ class MediaQuality(loader: ClassLoader, preferences: SharedPreferences) :
             Others.propsBoolean[6033] = true
             Others.propsBoolean[9569] = false
             Others.propsBoolean[26289] = true
-            // 26291 enables WhatsApp's Jarvis ML image-transcode config
-            // (UitTranscodeConfig/JarvisImageConfig) for this image mode. Its native
-            // passthrough decision mishandles HEIC/HEIF, uploading the source
-            // untranscoded so recipients get a corrupt image ("something wrong with
-            // the image file"). Left disabled; the maxKb/quality/maxEdge knobs above
-            // still deliver the quality boost.
             Others.propsBoolean[22375] = true
             listOf(1576, 2654, 6032, 15748, 3068).forEach { Others.propsInteger[it] = 3840 }
 


### PR DESCRIPTION
## Problem
Sending a HEIC/HEIF image with **HD Quality Images** enabled produces a corrupt upload - the recipient sees *"This image is not available because something is wrong with the image file."* Reproduced on WhatsApp 2.26.26.x.

## Root cause
`feat(MediaQuality): add configuration for improved media quality settings` (72624dff) sets five image-path A/B-prop booleans. One of them, **26291**, enables WhatsApp's Jarvis ML image-transcode config (`UitTranscodeConfig` / `JarvisImageConfig`) in `ProcessImageTaskConnector`:

```
if (abProps.A0s(z ? 26289 : 26291)) {
    processImageQuality.uitTranscodeConfig = new UitTranscodeConfig(jarvisImageConfig(...));
}
```

That path's native passthrough decision mishandles HEIC/HEIF: the source is uploaded without being transcoded to JPEG, so recipients can't decode it.

## How it was diagnosed
- On-device bisection (rooted, WA 2.26.26.73): both toggles off -> OK; **HD Images only -> broken**; HD Video only -> OK.
- Per-flag: `26289`+`26291` -> broken; `26289` only -> OK; **`26291` only -> broken**; all-except-`26291` -> OK.
- Confirmed the consumer with a runtime stack-trace hook on the boolean-prop getter (`C00D.A0s(int)`), then recovered the `ProcessImageTaskConnector` coroutine that reads it.
- `26289` is the same gate for a different image mode (unaffected); `6033`/`9569`/`22375` are inert or unrelated.

## Fix
Drop only `26291`, keeping the `maxKb`/`quality`/`maxEdge` quality knobs and the other props - the HD-image quality boost is preserved while HEIC/HEIF transcodes to JPEG correctly again.

Verified on-device: with the fix and HD Images enabled, HEIC images send and open correctly for the recipient.